### PR TITLE
Fix compatibility with Shoulder Surfing Reloaded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ repositories {
 
     maven { url 'https://maven.kosmx.dev/' }
     maven{ url"https://maven.bawnorton.com/releases"}
+    maven { url("https://raw.githubusercontent.com/Fuzss/modresources/main/maven/") }
 }
 
 dependencies {
@@ -66,6 +67,8 @@ dependencies {
     modCompileOnly fileTree(dir: "run/mods/compile", includes: ['*.jar'])
 
     modImplementation "maven.modrinth:sodium:${rootProject.sodium_version}-fabric"
+    modImplementation "fuzs.forgeconfigapiport:forgeconfigapiport-fabric:${rootProject.forge_config_api_port_version}"
+    modImplementation "maven.modrinth:shoulder-surfing-reloaded:${rootProject.shoulder_surfing_reloaded_version}+fabric"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ trinkets_version=3.10.0
 sodium_version=mc1.21.1-0.6.5
 owo_version=0.12.15.2+1.21
 obsidianui_version=0.2.9+mc1.21
+forge_config_api_port_version=21.1.0
+shoulder_surfing_reloaded_version=1.21.1-4.17.0

--- a/src/main/java/com/cleannrooster/dungeons_iso/compat/ShoulderSurfingCompat.java
+++ b/src/main/java/com/cleannrooster/dungeons_iso/compat/ShoulderSurfingCompat.java
@@ -1,0 +1,18 @@
+package com.cleannrooster.dungeons_iso.compat;
+
+import com.github.exopandora.shouldersurfing.api.client.ShoulderSurfing;
+import com.github.exopandora.shouldersurfing.api.model.Perspective;
+
+public class ShoulderSurfingCompat {
+    private static Perspective previousPerspective;
+
+    public static void onModEnabled() {
+        previousPerspective = Perspective.current();
+        ShoulderSurfing.getInstance().changePerspective(Perspective.THIRD_PERSON_BACK);
+    }
+
+    public static void onModDisabled() {
+        ShoulderSurfing.getInstance().changePerspective(previousPerspective);
+        previousPerspective = null;
+    }
+}

--- a/src/main/java/com/cleannrooster/dungeons_iso/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/cleannrooster/dungeons_iso/mixin/MinecraftClientMixin.java
@@ -3,6 +3,7 @@ package com.cleannrooster.dungeons_iso.mixin;
 import com.cleannrooster.dungeons_iso.api.*;
 import com.cleannrooster.dungeons_iso.compat.DragonCompat;
 import com.cleannrooster.dungeons_iso.compat.MidnightControlsCompat;
+import com.cleannrooster.dungeons_iso.compat.ShoulderSurfingCompat;
 import com.cleannrooster.dungeons_iso.compat.SodiumCompat;
 import com.cleannrooster.dungeons_iso.config.Config;
 import com.cleannrooster.dungeons_iso.ui.LootUI;
@@ -627,6 +628,9 @@ public abstract class MinecraftClientMixin implements MinecraftClientAccessor {
                 Mod.enabled = false;
 
                 options.setPerspective(Mod.lastPerspective);
+                if (FabricLoader.getInstance().isModLoaded("shouldersurfing")) {
+                    ShoulderSurfingCompat.onModDisabled();
+                }
                 Util.debug("Disabled Minecraft XIV");
                 if(client.currentScreen == null) {
                     InputUtil.setCursorParameters(client.getWindow().getHandle(), GLFW.GLFW_CURSOR_DISABLED,client.mouse.getX(), client.mouse.getY());
@@ -642,6 +646,9 @@ public abstract class MinecraftClientMixin implements MinecraftClientAccessor {
                 Mod.enabled = true;
 
                 Mod.lastPerspective = this.options.getPerspective();
+                if (FabricLoader.getInstance().isModLoaded("shouldersurfing")) {
+                    ShoulderSurfingCompat.onModEnabled();
+                }
                 this.options.setPerspective(Perspective.THIRD_PERSON_BACK);
                 if (Mod.lastPerspective == Perspective.THIRD_PERSON_FRONT) {
                     Mod.yaw = ((180 + this.player.getYaw() + 180) % 360) - 180;


### PR DESCRIPTION
Hi there! This PR fixes the compatibility with [Shoulder Surfing Reloaded](https://github.com/Exopandora/ShoulderSurfing), a third person camera mod. The issue was originally reported by @DoctorFlux in the Shoulder Surfing Reloaded repository. Please see [here](https://github.com/Exopandora/ShoulderSurfing/issues/381) for the original issue. They originally files this issue for 1.20.1, would it be also possible to backport this fix?